### PR TITLE
fix issue 5 (uri with null bytes (e.g. %00) were crashing the Static middleware)

### DIFF
--- a/src/tink/http/middleware/Static.hx
+++ b/src/tink/http/middleware/Static.hx
@@ -69,8 +69,10 @@ class StaticHandler implements HandlerObject {
 	public function process(req:IncomingRequest) {
 		var path:String = req.header.url.path;
 		if(req.header.method == GET && path.startsWith(prefix)) {
-			var staticPath = Path.join([root, path.substr(prefix.length).urlDecode()]);
-            if (staticPath.indexOf('\x00') > -1) return handler.process(req);  // decline considering anything with null bytes in this middleware
+			var decodedPath = try path.substr(prefix.length).urlDecode()
+							  catch (e:Dynamic) return handler.process(req);  // decline considering invalid urls in this middleware
+			var staticPath = Path.join([root, decodedPath]);
+			if (staticPath.indexOf('\x00') > -1) return handler.process(req);  // decline considering anything with null bytes in this middleware
 			#if asys
 				var result:Promise<OutgoingResponse> = FileSystem.exists(staticPath)
 					.next(function(exists) return if(!exists) notFound else FileSystem.isDirectory(staticPath))

--- a/src/tink/http/middleware/Static.hx
+++ b/src/tink/http/middleware/Static.hx
@@ -70,6 +70,7 @@ class StaticHandler implements HandlerObject {
 		var path:String = req.header.url.path;
 		if(req.header.method == GET && path.startsWith(prefix)) {
 			var staticPath = Path.join([root, path.substr(prefix.length).urlDecode()]);
+            if (staticPath.indexOf('\x00') > -1) return handler.process(req);  // decline considering anything with null bytes in this middleware
 			#if asys
 				var result:Promise<OutgoingResponse> = FileSystem.exists(staticPath)
 					.next(function(exists) return if(!exists) notFound else FileSystem.isDirectory(staticPath))

--- a/src/tink/http/middleware/Static.hx
+++ b/src/tink/http/middleware/Static.hx
@@ -70,7 +70,7 @@ class StaticHandler implements HandlerObject {
 		var path:String = req.header.url.path;
 		if(req.header.method == GET && path.startsWith(prefix)) {
 			var staticPath = Path.join([root, path.substr(prefix.length).urlDecode()]);
-            if (staticPath.indexOf('\x00') > -1) return handler.process(req);  // decline considering anything with null bytes in this middleware
+			if (staticPath.indexOf('\x00') > -1) return handler.process(req);  // decline considering anything with null bytes in this middleware
 			#if asys
 				var result:Promise<OutgoingResponse> = FileSystem.exists(staticPath)
 					.next(function(exists) return if(!exists) notFound else FileSystem.isDirectory(staticPath))

--- a/tests/StaticTest.hx
+++ b/tests/StaticTest.hx
@@ -62,6 +62,19 @@ class StaticTest {
 				});
 			}
 	}
+
+	@:describe('Invalid uris should not be handled by Static middleware')
+	public function testUrisWork() {
+		return new Static(folder, '/').apply(handler).process(req(GET, '/lets-%CREATE%an%invalid_%%%URL%')) >>
+			function(res:OutgoingResponse) {
+				asserts.assert(res.header.statusCode == 200);
+				asserts.assert(!res.header.byName('content-range').isSuccess());
+				return res.body.all().next(function(bytes) {
+					asserts.assert(bytes.toString() == 'GET');
+					return asserts.done();
+				});
+			}
+	}
 	
 	@:describe('Partial contents, both end specified')
 	public function testPartialContent() {


### PR DESCRIPTION
Fixing #5 

Cutting string at the first encountered null byte  and  removing null bytes both seem very dubious.
So I went with Static middleware ignoring any uri with a path containing a null byte.